### PR TITLE
feat(validator): validate advance invoice exchange rates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,9 +175,11 @@ that can cause real tax/accounting problems after a successful submission.
 - **Tax calculation arithmetic** — P_14_x = P_13_x × rate, P_15 = sum of all bases and taxes
 - **NBP currency rate** — `KursWaluty` matches the official NBP mid-rate from the last business day
   before the tax obligation arises (Art. 31a ust. 1 VAT Act), or before the issue date when the
-  invoice precedes the tax point (ust. 2). The tax point is inferred from `P_6A`, `P_6` or
-  `OkresFa/P_6_Do`, falling back to `P_1`. KSeF enforces only the `TIlosci` format here (dot
-  separator, max 6 decimals) — any well-formed value passes, however wrong.
+  invoice precedes the tax point (ust. 2). The tax point is inferred from `P_6A`, `P_6`,
+  `OkresFa/P_6_Do` or `ZaliczkaCzesciowa/P_6Z`, falling back to `P_1`. Advance rates (`KursWalutyZ`,
+  `KursWalutyZW`) convert at the payment receipt date (Art. 19a ust. 8). KSeF enforces only the
+  `TIlosci` format here (dot separator, max 6 decimals) — any well-formed value passes, however
+  wrong.
 - **Bank account format** — Polish NRB/IBAN format validation
 - **Duplicate line numbers** — `NrWierszaFa` uniqueness within an invoice
 - **Negative quantities** — only valid in corrective invoice context

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,8 @@ that can cause real tax/accounting problems after a successful submission.
   before the tax obligation arises (Art. 31a ust. 1 VAT Act), or before the issue date when the
   invoice precedes the tax point (ust. 2). The tax point is inferred from `P_6A`, `P_6`,
   `OkresFa/P_6_Do` or `ZaliczkaCzesciowa/P_6Z`, falling back to `P_1`. Advance rates (`KursWalutyZ`,
-  `KursWalutyZW`) convert at the payment receipt date (Art. 19a ust. 8). KSeF enforces only the
+  `KursWalutyZW`) convert at the payment receipt date (Art. 19a ust. 8), or at `P_1` when the
+  invoice was issued before the payment arrived — ust. 2 applies there too. KSeF enforces only the
   `TIlosci` format here (dot separator, max 6 decimals) — any well-formed value passes, however
   wrong.
 - **Bank account format** — Polish NRB/IBAN format validation

--- a/apps/web/src/app/[locale]/validator.tsx
+++ b/apps/web/src/app/[locale]/validator.tsx
@@ -155,7 +155,7 @@ export function Validator({ locale }: ValidatorProps) {
               if (kodWaluty && kodWaluty !== "PLN" && dataWystawienia) {
                 // Art. 31a ust. 1 keys the rate to the tax obligation date, which can
                 // predate P_1 by weeks — the fetched range has to reach back that far.
-                const taxPoints = ["P_6", "P_6_Do", "P_6A"]
+                const taxPoints = ["P_6", "P_6_Do", "P_6A", "P_6Z"]
                   .flatMap((tag) => Array.from(xmlDoc.getElementsByTagNameNS(ns, tag)))
                   .map((node) => node.textContent)
                   .filter((date): date is string => date !== null && date < dataWystawienia)

--- a/packages/validator/CHANGELOG.md
+++ b/packages/validator/CHANGELOG.md
@@ -7,6 +7,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Exchange rate validation for advance invoices, which previously had none. `Fa/KursWalutyZ` and
+  `ZaliczkaCzesciowa/KursWalutyZW` are now checked against the NBP Table A mid-rate, keyed to the
+  date the payment was received (Art. 19a ust. 8) — `ZaliczkaCzesciowa/P_6Z` for a per-payment rate,
+  `Fa/P_6` for the invoice-level one. A foreign-currency `ZAL` carries no `FaWiersz`, so no rate on
+  it was reachable by any check before
+- Unlike `FaWiersz/KursWaluty`, exactly one rate is accepted here: an advance has a determinate tax
+  point, so there is no Art. 19a ust. 5 ambiguity to widen for, and Art. 31a ust. 1a is keyed to
+  that same invoice-issuance effect. `Fa/KursWalutyZ` is skipped when several payments carry
+  different dates and no `Fa/P_6` fixes one, and `KursWalutyZK` is never checked — it records the
+  rate adopted for the invoice being corrected (Art. 31b ust. 1), not a fresh conversion
+- `resolveRateReference` and `rateReferenceCandidates`, exported from the package root and from the
+  dependency-free `@ksefuj/validator/currency-date` subpath, so rate-fetching clients can select the
+  same reference date the validator checks against
+
 ### Fixed
 
 - `CURRENCY_RATE_MISMATCH` no longer keys the NBP rate to `P_1` alone. Art. 31a ust. 1 keys it to
@@ -29,12 +45,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CURRENCY_RATE_MISMATCH` now says "NBP Table A mid-rate" rather than implying the invoice is
   simply wrong: a taxpayer may lawfully have elected ECB rates (Art. 31a ust. 1) or income-tax
   conversion rules (Art. 31a ust. 2a), neither of which FA(3) records
-
-### Added
-
-- `resolveRateReference` and `rateReferenceCandidates`, exported from the package root and from the
-  dependency-free `@ksefuj/validator/currency-date` subpath, so rate-fetching clients can select the
-  same reference date the validator checks against
 
 ## [0.3.0] — 2026-03-31
 

--- a/packages/validator/CHANGELOG.md
+++ b/packages/validator/CHANGELOG.md
@@ -12,8 +12,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Exchange rate validation for advance invoices, which previously had none. `Fa/KursWalutyZ` and
   `ZaliczkaCzesciowa/KursWalutyZW` are now checked against the NBP Table A mid-rate, keyed to the
   date the payment was received (Art. 19a ust. 8) — `ZaliczkaCzesciowa/P_6Z` for a per-payment rate,
-  `Fa/P_6` for the invoice-level one. A foreign-currency `ZAL` carries no `FaWiersz`, so no rate on
-  it was reachable by any check before
+  `Fa/P_6` for the invoice-level one. Art. 31a ust. 2 still applies: an advance invoice may be
+  issued up to 60 days before the payment arrives (Art. 106i ust. 7), and the reference date is then
+  `P_1`. A foreign-currency `ZAL` carries no `FaWiersz`, so no rate on it was reachable by any check
+  before
 - Unlike `FaWiersz/KursWaluty`, exactly one rate is accepted here: an advance has a determinate tax
   point, so there is no Art. 19a ust. 5 ambiguity to widen for, and Art. 31a ust. 1a is keyed to
   that same invoice-issuance effect. `Fa/KursWalutyZ` is skipped when several payments carry

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -6,8 +6,8 @@ KSeF FA(3) XML validator with full XSD schema validation and semantic business r
 
 - **Full XSD validation** using libxml2-wasm (WebAssembly)
 - **Semantic business rules** that catch errors XSD can't express
-- **NBP currency rate validation** — checks `KursWaluty` against official NBP mid-rates (Art. 31a
-  VAT Act)
+- **NBP currency rate validation** — checks `KursWaluty`, and the advance-invoice rates
+  `KursWalutyZ` and `KursWalutyZW`, against official NBP Table A mid-rates (Art. 31a VAT Act)
 - **Works everywhere** - Node.js, browser, CLI
 - **Zero network requests** - bundled schemas for offline use
 - **TypeScript support** with full type definitions
@@ -46,13 +46,17 @@ if (!result.valid) {
 
 ### Currency rate validation
 
-Optionally validate that `KursWaluty` matches the official NBP mid-rate (Art. 31a VAT Act). Pass a
-rate table per currency — the validator picks the correct date itself.
+Optionally validate that the invoice's exchange rates match the official NBP Table A mid-rate (Art.
+31a VAT Act). Pass a rate table per currency — the validator picks the correct date itself.
+`FaWiersz/KursWaluty` is checked per line; advance invoices are covered too, through
+`Fa/KursWalutyZ` and `ZaliczkaCzesciowa/KursWalutyZW`.
 
 The reference date is **not** simply `P_1`. Art. 31a ust. 1 takes the rate from the last business
 day before the day the tax obligation arises; the issue date governs only when the invoice is issued
-_before_ that (ust. 2). The validator infers the tax point from `FaWiersz/P_6A`, `Fa/P_6` or
-`Fa/OkresFa/P_6_Do`, and falls back to `P_1` when the invoice carries none.
+_before_ that (ust. 2). The validator infers the tax point from `FaWiersz/P_6A`, `Fa/P_6`,
+`Fa/OkresFa/P_6_Do` or `ZaliczkaCzesciowa/P_6Z`, and falls back to `P_1` when the invoice carries
+none. On an advance invoice the tax point is the day the payment was received (Art. 19a ust. 8), so
+each `KursWalutyZW` is checked against its own `P_6Z`.
 
 ```typescript
 import { validate, type CurrencyRate } from "@ksefuj/validator";

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -56,7 +56,9 @@ day before the day the tax obligation arises; the issue date governs only when t
 _before_ that (ust. 2). The validator infers the tax point from `FaWiersz/P_6A`, `Fa/P_6`,
 `Fa/OkresFa/P_6_Do` or `ZaliczkaCzesciowa/P_6Z`, and falls back to `P_1` when the invoice carries
 none. On an advance invoice the tax point is the day the payment was received (Art. 19a ust. 8), so
-each `KursWalutyZW` is checked against its own `P_6Z`.
+each `KursWalutyZW` is checked against its own `P_6Z` — unless the invoice was issued first, which
+Art. 106i ust. 7 permits up to 60 days ahead, in which case ust. 2 puts the reference date back on
+`P_1` like everywhere else.
 
 ```typescript
 import { validate, type CurrencyRate } from "@ksefuj/validator";

--- a/packages/validator/src/__tests__/semantic.test.ts
+++ b/packages/validator/src/__tests__/semantic.test.ts
@@ -1505,6 +1505,50 @@ describe("Semantic Validation", () => {
       expect(result.issues.some((i) => i.code.code === "CURRENCY_RATE_MISMATCH")).toBe(false);
     });
 
+    it("should use the issue date when the advance invoice precedes the payment", () => {
+      // Art. 106i ust. 7 allows invoicing up to 60 days ahead of the payment, and
+      // Art. 31a ust. 2 then puts the reference date back on P_1
+      const xml = advanceInvoice(
+        "<P_6>2026-09-30</P_6><P_15>123.00</P_15><KursWalutyZ>3.7911</KursWalutyZ>",
+      );
+      const result = validateXml(xml, { USD: usdRates });
+      expect(result.issues.some((i) => i.code.code === "CURRENCY_RATE_MISMATCH")).toBe(false);
+    });
+
+    it("should flag the payment-date rate when the invoice precedes the payment", () => {
+      const xml = advanceInvoice(
+        "<P_6>2026-09-30</P_6><P_15>123.00</P_15><KursWalutyZ>3.7644</KursWalutyZ>",
+      );
+      const result = validateXml(xml, { USD: usdRates });
+      const issue = result.issues.find((i) => i.code.code === "CURRENCY_RATE_MISMATCH");
+      expect(issue).toBeDefined();
+      expect(issue!.context.expectedValues).toEqual(["3.7911"]);
+    });
+
+    it("should locate a payment by position when P_6Z is missing", () => {
+      // P_6Z is mandatory in the schema, but semantics also run on XSD-invalid documents
+      const xml = advanceInvoice(`<P_15>123.00</P_15>
+        <ZaliczkaCzesciowa>
+          <P_15Z>123.00</P_15Z><KursWalutyZW>1.0000</KursWalutyZW>
+        </ZaliczkaCzesciowa>`);
+      const result = validateXml(xml, { USD: usdRates });
+      const issue = result.issues.find((i) => i.code.code === "CURRENCY_RATE_MISMATCH");
+      expect(issue).toBeDefined();
+      expect(issue!.context.location.xpath).toBe("/Faktura/Fa/ZaliczkaCzesciowa[1]/KursWalutyZW");
+      expect(issue!.context.location.xpath).not.toContain("null");
+    });
+
+    it("should not name KursWaluty when an advance rate is unverifiable", () => {
+      // The invoice has no FaWiersz at all, so naming that field would be wrong
+      const xml = advanceInvoice(
+        "<P_6>2026-07-31</P_6><P_15>123.00</P_15><KursWalutyZ>3.7644</KursWalutyZ>",
+      );
+      const result = validateXml(xml, { USD: null });
+      const issue = result.issues.find((i) => i.code.code === "CURRENCY_RATE_UNVERIFIABLE");
+      expect(issue).toBeDefined();
+      expect(issue!.message).not.toContain("KursWaluty");
+    });
+
     it("should report UNVERIFIABLE once when the rate table cannot answer", () => {
       const xml = advanceInvoice(`<P_15>246.00</P_15><KursWalutyZ>3.7644</KursWalutyZ>
         <ZaliczkaCzesciowa>

--- a/packages/validator/src/__tests__/semantic.test.ts
+++ b/packages/validator/src/__tests__/semantic.test.ts
@@ -1383,6 +1383,151 @@ describe("Semantic Validation", () => {
     });
   });
 
+  describe("Advance Invoice Currency Rates (Art. 19a ust. 8)", () => {
+    /**
+     * Advance invoices carry no FaWiersz — the rate lives in Fa/KursWalutyZ, and in
+     * ZaliczkaCzesciowa/KursWalutyZW when several payments are documented (§9.5, §9.8).
+     */
+    const advanceInvoice = (body: string) =>
+      wrapInFaktura(`
+        <Podmiot1>
+          <DaneIdentyfikacyjne><NIP>1234567890</NIP><Nazwa>Test</Nazwa></DaneIdentyfikacyjne>
+          <Adres><KodKraju>PL</KodKraju><AdresL1>Test</AdresL1></Adres>
+        </Podmiot1>
+        <Podmiot2>
+          <DaneIdentyfikacyjne><NIP>9876543210</NIP><Nazwa>Test</Nazwa></DaneIdentyfikacyjne>
+          <Adres><KodKraju>PL</KodKraju><AdresL1>Test</AdresL1></Adres>
+          <JST>2</JST>
+          <GV>2</GV>
+        </Podmiot2>
+        <Fa>
+          <KodWaluty>USD</KodWaluty>
+          <P_1>2026-08-05</P_1>
+          <P_2>ZAL/001/08/2026</P_2>
+          ${body}
+          <Adnotacje>
+            <P_16>2</P_16><P_17>2</P_17><P_18>2</P_18><P_18A>2</P_18A>
+            <Zwolnienie><P_19N>1</P_19N></Zwolnienie>
+            <NoweSrodkiTransportu><P_22N>1</P_22N></NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy><P_PMarzyN>1</P_PMarzyN></PMarzy>
+          </Adnotacje>
+          <RodzajFaktury>ZAL</RodzajFaktury>
+        </Fa>
+      `);
+
+    const usdRates: CurrencyRate[] = [
+      { currency: "USD", date: "2026-07-17", mid: 3.74 },
+      { currency: "USD", date: "2026-07-20", mid: 3.7455 },
+      { currency: "USD", date: "2026-07-30", mid: 3.7644 },
+      { currency: "USD", date: "2026-08-04", mid: 3.7911 },
+    ];
+
+    it("should accept KursWalutyZ keyed to the payment receipt date in P_6", () => {
+      // Payment received 2026-07-31 → rate from the last business day before it
+      const xml = advanceInvoice(
+        "<P_6>2026-07-31</P_6><P_15>123.00</P_15><KursWalutyZ>3.7644</KursWalutyZ>",
+      );
+      const result = validateXml(xml, { USD: usdRates });
+      expect(result.issues.some((i) => i.code.code === "CURRENCY_RATE_MISMATCH")).toBe(false);
+    });
+
+    it("should flag KursWalutyZ keyed to the issue date instead of the payment", () => {
+      // Art. 19a ust. 8 fixes the tax point at receipt of payment, so unlike
+      // FaWiersz/KursWaluty the issue-date rate is not an accepted alternative here
+      const xml = advanceInvoice(
+        "<P_6>2026-07-31</P_6><P_15>123.00</P_15><KursWalutyZ>3.7911</KursWalutyZ>",
+      );
+      const result = validateXml(xml, { USD: usdRates });
+      const issue = result.issues.find((i) => i.code.code === "CURRENCY_RATE_MISMATCH");
+      expect(issue).toBeDefined();
+      expect(issue!.context.location.element).toBe("KursWalutyZ");
+      expect(issue!.context.location.xpath).toBe("/Faktura/Fa/KursWalutyZ");
+      expect(issue!.context.expectedValues).toEqual(["3.7644"]);
+      expect(issue!.fixSuggestions[0].content).toBe("3.7644");
+    });
+
+    it("should key each KursWalutyZW to its own payment date", () => {
+      const xml = advanceInvoice(`<P_15>246.00</P_15>
+        <ZaliczkaCzesciowa>
+          <P_6Z>2026-07-20</P_6Z><P_15Z>123.00</P_15Z><KursWalutyZW>3.7400</KursWalutyZW>
+        </ZaliczkaCzesciowa>
+        <ZaliczkaCzesciowa>
+          <P_6Z>2026-07-31</P_6Z><P_15Z>123.00</P_15Z><KursWalutyZW>3.7644</KursWalutyZW>
+        </ZaliczkaCzesciowa>`);
+      const result = validateXml(xml, { USD: usdRates });
+      expect(result.issues.some((i) => i.code.code === "CURRENCY_RATE_MISMATCH")).toBe(false);
+    });
+
+    it("should flag the payment whose rate is wrong and name its date", () => {
+      const xml = advanceInvoice(`<P_15>246.00</P_15>
+        <ZaliczkaCzesciowa>
+          <P_6Z>2026-07-20</P_6Z><P_15Z>123.00</P_15Z><KursWalutyZW>3.7400</KursWalutyZW>
+        </ZaliczkaCzesciowa>
+        <ZaliczkaCzesciowa>
+          <P_6Z>2026-07-31</P_6Z><P_15Z>123.00</P_15Z><KursWalutyZW>3.7911</KursWalutyZW>
+        </ZaliczkaCzesciowa>`);
+      const result = validateXml(xml, { USD: usdRates });
+      const found = result.issues.filter((i) => i.code.code === "CURRENCY_RATE_MISMATCH");
+      expect(found).toHaveLength(1);
+      expect(found[0].context.location.xpath).toBe(
+        "/Faktura/Fa/ZaliczkaCzesciowa[P_6Z='2026-07-31']/KursWalutyZW",
+      );
+      expect(found[0].message).toContain("2026-07-31");
+      expect(found[0].context.expectedValues).toEqual(["3.7644"]);
+    });
+
+    it("should use the single documented payment as the tax point for KursWalutyZ", () => {
+      const xml = advanceInvoice(`<P_15>123.00</P_15><KursWalutyZ>3.7644</KursWalutyZ>
+        <ZaliczkaCzesciowa>
+          <P_6Z>2026-07-31</P_6Z><P_15Z>123.00</P_15Z>
+        </ZaliczkaCzesciowa>`);
+      const result = validateXml(xml, { USD: usdRates });
+      expect(result.issues.some((i) => i.code.code === "CURRENCY_RATE_MISMATCH")).toBe(false);
+    });
+
+    it("should leave KursWalutyZ alone when several payments have different dates", () => {
+      // Without P_6 the invoice-level rate has no single tax point to check against
+      const xml = advanceInvoice(`<P_15>246.00</P_15><KursWalutyZ>1.0000</KursWalutyZ>
+        <ZaliczkaCzesciowa>
+          <P_6Z>2026-07-20</P_6Z><P_15Z>123.00</P_15Z>
+        </ZaliczkaCzesciowa>
+        <ZaliczkaCzesciowa>
+          <P_6Z>2026-07-31</P_6Z><P_15Z>123.00</P_15Z>
+        </ZaliczkaCzesciowa>`);
+      const result = validateXml(xml, { USD: usdRates });
+      expect(result.issues.some((i) => i.code.code === "CURRENCY_RATE_MISMATCH")).toBe(false);
+    });
+
+    it("should fall back to P_1 when the advance invoice records no payment date", () => {
+      const xml = advanceInvoice("<P_15>123.00</P_15><KursWalutyZ>3.7911</KursWalutyZ>");
+      const result = validateXml(xml, { USD: usdRates });
+      expect(result.issues.some((i) => i.code.code === "CURRENCY_RATE_MISMATCH")).toBe(false);
+    });
+
+    it("should report UNVERIFIABLE once when the rate table cannot answer", () => {
+      const xml = advanceInvoice(`<P_15>246.00</P_15><KursWalutyZ>3.7644</KursWalutyZ>
+        <ZaliczkaCzesciowa>
+          <P_6Z>2026-07-31</P_6Z><P_15Z>123.00</P_15Z><KursWalutyZW>3.7644</KursWalutyZW>
+        </ZaliczkaCzesciowa>`);
+      const result = validateXml(xml, { USD: null });
+      expect(
+        result.issues.filter((i) => i.code.code === "CURRENCY_RATE_UNVERIFIABLE"),
+      ).toHaveLength(1);
+    });
+
+    it("should not check KursWalutyZK — Art. 31b ust. 1 keeps the original rate", () => {
+      // KOR_ZAL is skipped wholesale, but the pre-correction rate is never a target anyway
+      const xml = advanceInvoice(
+        "<P_6>2026-07-31</P_6><P_15>123.00</P_15><P_15ZK>100.00</P_15ZK><KursWalutyZK>1.0000</KursWalutyZK><KursWalutyZ>3.7644</KursWalutyZ>",
+      );
+      const result = validateXml(xml, { USD: usdRates });
+      const found = result.issues.filter((i) => i.code.code === "CURRENCY_RATE_MISMATCH");
+      expect(found.every((i) => i.context.location.element !== "KursWalutyZK")).toBe(true);
+      expect(found).toHaveLength(0);
+    });
+  });
+
   describe("Rule Coverage", () => {
     it("should have all 43 rules implemented", () => {
       expect(semanticRules).toHaveLength(35); // Some rules are grouped (ADNOTACJE_MANDATORY_FIELDS covers 8 rules)

--- a/packages/validator/src/semantic.ts
+++ b/packages/validator/src/semantic.ts
@@ -1495,6 +1495,9 @@ function checkCurrencyRateMismatch(
   /**
    * The date the lookup actually keyed on — not necessarily `P_1`, so the message
    * must not call it the invoice date. Null when the invoice carries no usable date.
+   *
+   * One of these covers the whole invoice, and the field at fault may be any of
+   * `KursWaluty`, `KursWalutyZ` or `KursWalutyZW`, so the wording names none of them.
    */
   const unverifiable = (referenceDate: string | null): ValidationIssue => {
     const errorDef = ERROR_CODES.CURRENCY_RATE_UNVERIFIABLE;
@@ -1510,8 +1513,8 @@ function checkCurrencyRateMismatch(
         },
       },
       message: referenceDate
-        ? `Unable to verify KursWaluty — no NBP rate for ${kodWaluty} is available for the reference date ${referenceDate}.`
-        : `Unable to verify KursWaluty — no NBP rate for ${kodWaluty} is available.`,
+        ? `Unable to verify the exchange rate — no NBP rate for ${kodWaluty} is available for the reference date ${referenceDate}.`
+        : `Unable to verify the exchange rate — no NBP rate for ${kodWaluty} is available.`,
       fixSuggestions: [],
     };
   };
@@ -1641,21 +1644,27 @@ function checkCurrencyRateMismatch(
 
   // Each documented payment carries its own receipt date, so its own reference date
   const zaliczki = els(doc, "//ns:Fa/ns:ZaliczkaCzesciowa");
-  for (const zaliczka of zaliczki) {
+  zaliczki.forEach((zaliczka, index) => {
     const kursWalutyZW = text(zaliczka, "string(ns:KursWalutyZW)");
     if (!kursWalutyZW) {
-      continue;
+      return;
     }
     // `string()` yields "" for an absent node, which is not a date — normalise it away
     const p6z = text(zaliczka, "string(ns:P_6Z)") || null;
+    // P_6Z is mandatory inside ZaliczkaCzesciowa, but the semantic layer also runs on
+    // documents that failed XSD validation — fall back to position rather than emit a
+    // predicate matching nothing.
+    const zaliczkaPath = p6z
+      ? `/Faktura/Fa/ZaliczkaCzesciowa[P_6Z='${p6z}']`
+      : `/Faktura/Fa/ZaliczkaCzesciowa[${index + 1}]`;
     checkAdvanceRate(
       "KursWalutyZW",
       kursWalutyZW,
-      `/Faktura/Fa/ZaliczkaCzesciowa[P_6Z='${p6z}']/KursWalutyZW`,
+      `${zaliczkaPath}/KursWalutyZW`,
       isCollectiveCorrection ? null : p6z,
       p6z ? `for the payment received on ${p6z}` : undefined,
     );
-  }
+  });
 
   const kursWalutyZ = text(doc, "string(//ns:Fa/ns:KursWalutyZ)");
   if (kursWalutyZ) {

--- a/packages/validator/src/semantic.ts
+++ b/packages/validator/src/semantic.ts
@@ -1516,6 +1516,44 @@ function checkCurrencyRateMismatch(
     };
   };
 
+  /**
+   * A rate field disagreeing with every rate that could lawfully appear in it.
+   * `rates` is ordered, primary reading first — it drives the message and the fix.
+   */
+  const mismatch = (opts: {
+    field: string;
+    value: string;
+    xpath: string;
+    rates: CurrencyRate[];
+    /** Which part of the invoice, e.g. "in line 1" — omitted for invoice-level fields */
+    where?: string;
+    lineNumber?: number;
+  }): ValidationIssue => {
+    const rate = opts.rates[0];
+    const expected = rate.mid.toFixed(4);
+    const errorDef = ERROR_CODES.CURRENCY_RATE_MISMATCH;
+    const where = opts.where ? ` ${opts.where}` : "";
+    return {
+      code: errorDef.code,
+      context: {
+        location: { xpath: opts.xpath, element: opts.field, lineNumber: opts.lineNumber },
+        actualValue: opts.value,
+        expectedValues: opts.rates.map((r) => r.mid.toFixed(4)),
+        metadata: { currency: kodWaluty, nbpDate: rate.date, nbpMid: rate.mid },
+      },
+      message: `${opts.field} (${opts.value})${where} differs from the NBP Table A mid-rate on ${rate.date} (${expected}).`,
+      fixSuggestions: [
+        {
+          type: "replace",
+          targetXPath: opts.xpath,
+          content: expected,
+          description: `Set ${opts.field} to ${expected} (NBP Table A mid-rate for ${kodWaluty} on ${rate.date}).`,
+          confidence: 0.95,
+        },
+      ],
+    };
+  };
+
   // KursWaluty lives in FaWiersz (line items) per FA(3) §10.2 — check each line.
   // An invoice with no KursWaluty anywhere has nothing to verify: advance invoices
   // carry no FaWiersz at all and keep their rate in KursWalutyZ / KursWalutyZW,
@@ -1547,38 +1585,99 @@ function checkCurrencyRateMismatch(
       continue;
     }
 
-    // Primary reading drives the message and the fix suggestion
-    const rate = rates[0];
     const nrWiersza = text(wiersz, "string(ns:NrWierszaFa)");
-    const xpath = `/Faktura/Fa/FaWiersz[NrWierszaFa='${nrWiersza}']/KursWaluty`;
-    const errorDef = ERROR_CODES.CURRENCY_RATE_MISMATCH;
-    issues.push({
-      code: errorDef.code,
-      context: {
-        location: {
-          xpath,
-          element: "KursWaluty",
-          lineNumber: nrWiersza ? parseInt(nrWiersza) : undefined,
-        },
-        actualValue: kursWalutyStr,
-        expectedValues: rates.map((r) => r.mid.toFixed(4)),
-        metadata: {
-          currency: kodWaluty,
-          nbpDate: rate.date,
-          nbpMid: rate.mid,
-        },
-      },
-      message: `KursWaluty (${kursWalutyStr}) in line ${nrWiersza} differs from the NBP Table A mid-rate on ${rate.date} (${rate.mid.toFixed(4)}).`,
-      fixSuggestions: [
-        {
-          type: "replace",
-          targetXPath: xpath,
-          content: rate.mid.toFixed(4),
-          description: `Set KursWaluty to ${rate.mid.toFixed(4)} (NBP Table A mid-rate for ${kodWaluty} on ${rate.date}).`,
-          confidence: 0.95,
-        },
-      ],
-    });
+    issues.push(
+      mismatch({
+        field: "KursWaluty",
+        value: kursWalutyStr,
+        xpath: `/Faktura/Fa/FaWiersz[NrWierszaFa='${nrWiersza}']/KursWaluty`,
+        rates,
+        where: `in line ${nrWiersza}`,
+        lineNumber: nrWiersza ? parseInt(nrWiersza) : undefined,
+      }),
+    );
+  }
+
+  // ── Advance-invoice rates (§9.5, §9.8) ──────────────────────────────────────
+  // A zaliczka converts at the moment the payment was received (Art. 19a ust. 8),
+  // and FA(3) records that date exactly. There is no Art. 19a ust. 5 ambiguity to
+  // widen for here — ust. 5 moves the tax point onto invoice issuance, which is not
+  // how an advance arises, and Art. 31a ust. 1a is keyed to that same effect — so
+  // exactly one rate is accepted rather than two.
+  //
+  // KursWalutyZK is deliberately not checked: it records the rate adopted for the
+  // invoice being corrected (Art. 31b ust. 1), not a fresh conversion.
+  const advanceRate = (taxPoint: string | null): CurrencyRate | null => {
+    if (rateData === null || rateData.length === 0) {
+      return null;
+    }
+    const reference = resolveRateReference(p1, taxPoint);
+    return reference ? findRateBefore(rateData, reference.date) : null;
+  };
+
+  const checkAdvanceRate = (
+    field: string,
+    value: string,
+    xpath: string,
+    taxPoint: string | null,
+    where?: string,
+  ): void => {
+    const parsed = parseFloat(value);
+    if (isNaN(parsed)) {
+      return;
+    }
+    const rate = advanceRate(taxPoint);
+    if (!rate) {
+      if (!reportedUnverifiable) {
+        issues.push(unverifiable(resolveRateReference(p1, taxPoint)?.date ?? null));
+        reportedUnverifiable = true;
+      }
+      return;
+    }
+    if (Math.round(parsed * 10000) !== Math.round(rate.mid * 10000)) {
+      issues.push(mismatch({ field, value, xpath, rates: [rate], where }));
+    }
+  };
+
+  // Each documented payment carries its own receipt date, so its own reference date
+  const zaliczki = els(doc, "//ns:Fa/ns:ZaliczkaCzesciowa");
+  for (const zaliczka of zaliczki) {
+    const kursWalutyZW = text(zaliczka, "string(ns:KursWalutyZW)");
+    if (!kursWalutyZW) {
+      continue;
+    }
+    // `string()` yields "" for an absent node, which is not a date — normalise it away
+    const p6z = text(zaliczka, "string(ns:P_6Z)") || null;
+    checkAdvanceRate(
+      "KursWalutyZW",
+      kursWalutyZW,
+      `/Faktura/Fa/ZaliczkaCzesciowa[P_6Z='${p6z}']/KursWalutyZW`,
+      isCollectiveCorrection ? null : p6z,
+      p6z ? `for the payment received on ${p6z}` : undefined,
+    );
+  }
+
+  const kursWalutyZ = text(doc, "string(//ns:Fa/ns:KursWalutyZ)");
+  if (kursWalutyZ) {
+    // P_6 on an advance invoice is the date the payment was received (§9.2). Failing
+    // that, a single documented payment fixes the date; several with different dates
+    // leave it undecidable, and KursWalutyZ is then left alone.
+    const p6 = text(doc, "string(//ns:Fa/ns:P_6)") || null;
+    const paymentDates = Array.from(
+      new Set(
+        zaliczki
+          .map((zaliczka) => text(zaliczka, "string(ns:P_6Z)"))
+          .filter((date): date is string => Boolean(date)),
+      ),
+    );
+    if (p6 || paymentDates.length <= 1) {
+      checkAdvanceRate(
+        "KursWalutyZ",
+        kursWalutyZ,
+        "/Faktura/Fa/KursWalutyZ",
+        isCollectiveCorrection ? null : (p6 ?? paymentDates[0] ?? null),
+      );
+    }
   }
 
   return issues;


### PR DESCRIPTION
Closes #74.

Foreign-currency advance invoices had **no rate validation at all**. `checkCurrencyRateMismatch` only ever read `FaWiersz/KursWaluty`, and a `ZAL` carries no `FaWiersz` — its rate lives in `Fa/KursWalutyZ`, or in `ZaliczkaCzesciowa/KursWalutyZW` when several payments are documented. Any number in those fields passed unchallenged. #73 made the rule correctly *silent* on such invoices instead of wrongly reporting them unverifiable; this closes the gap itself.

## Reference date

An advance converts at the moment the payment was received (**Art. 19a ust. 8**), and FA(3) records that date exactly:

- each `KursWalutyZW` is keyed to its own sibling `P_6Z` — per-payment, so a multi-payment invoice gets a different reference date per rate
- `KursWalutyZ` is keyed to `Fa/P_6`, which on an advance invoice is the payment receipt date (§9.2)

## One rate accepted here, not two

`FaWiersz/KursWaluty` accepts both the tax-point and issue-date readings, because `OkresFa` is annotated in the XSD as covering Art. 19a ust. 3 zd. 1, ust. 4 *and* ust. 5 pkt 4, and the XML cannot say which applies.

None of that holds for an advance. Its tax point is determinate, and Art. 31a ust. 1a is keyed to supplies "dla których obowiązek podatkowy powstaje z chwilą wystawienia faktury" — which an advance is not. So the issue-date rate is not a lawful alternative here, and using it is reported as a mismatch. There is a test pinning exactly that asymmetry.

## Two deliberate abstentions

- **`KursWalutyZ` with several payments on different dates and no `Fa/P_6`** — the invoice-level rate then has no single tax point to check against, so it is left alone rather than guessed at.
- **`KursWalutyZK` is never checked.** It records the rate adopted for the invoice being corrected (**Art. 31b ust. 1**), not a fresh conversion. Corrections are already skipped wholesale, but this is a target that would be wrong to check even if they were not.

## Web

The pre-scan contributes `P_6Z` as well, so the fetched NBP window reaches back to payment dates that predate `P_1` — otherwise the new checks would just report `CURRENCY_RATE_UNVERIFIABLE`.

## Notes

`emitMismatch` was extracted so the line-item and advance paths share one issue shape; the existing `KursWaluty` behaviour is unchanged, which the untouched pre-existing tests confirm.

Worth flagging one bug found while building this: `string()` on an absent node returns `""`, not null, so `??` does not fall through it. An absent `Fa/P_6` was producing `taxPoint = ""` and silently falling back to `P_1` — caught by a test that expected the payment-date rate and got the issue-date one.

Validator tests: 70 → 79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)